### PR TITLE
Detect Tuned profile and incorporate into custom profile

### DIFF
--- a/lib/facter/tuned.active.rb
+++ b/lib/facter/tuned.active.rb
@@ -1,0 +1,49 @@
+require 'facter'
+
+def get_active_profile
+  active_profile = ""
+  begin
+    if File.file?('/etc/tuned/active_profile') then
+      active_profile = File.read('/etc/tuned/active_profile').chomp
+    else
+      active_profile = `tuned-adm active`.chomp.sub('Current active profile: ','')
+      if $?.exitstatus != 0 then
+        active_profile = 'virtual-guest'
+      end
+    end
+  rescue
+    active_profile = 'virtual-guest'
+  end
+
+  active_profile
+end
+
+Facter.add(:tuned_active_profile) do
+  confine :kernel => "Linux"
+  setcode do
+    get_active_profile()
+  end
+end
+
+Facter.add(:tuned_base_profile) do
+  confine :kernel => "Linux"
+  setcode do
+    active_profile = get_active_profile()
+    base_profile = ""
+    if active_profile == "custom" then
+      begin
+        File.open('/etc/tuned/custom/tuned.conf').each do |line|
+          if line.match("include=") then
+            base_profile = line.chomp.sub('include=','')
+          end
+        end
+      rescue
+        base_profile = 'virtual-guest'
+      end
+    else
+      base_profile = active_profile
+    end
+
+    base_profile
+  end
+end

--- a/lib/facter/tuned.active.rb
+++ b/lib/facter/tuned.active.rb
@@ -1,7 +1,7 @@
 require 'facter'
 
 def get_active_profile
-  active_profile = ""
+  active_profile = ''
   begin
     if File.file?('/etc/tuned/active_profile') then
       active_profile = File.read('/etc/tuned/active_profile').chomp

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,13 +47,14 @@ class disable_transparent_hugepage (
       content => template("${module_name}/tuned.conf.erb"),
     }
 
-    exec { 'enable-tuned-profile':
-      command => '/sbin/tuned-adm profile custom',
-      unless  => '/sbin/tuned-adm active | grep -q "custom"',
-    }
+    if $::tuned_active_profile != 'custom' {
+      exec { 'enable-tuned-profile':
+        command => '/sbin/tuned-adm profile custom',
+      }
 
-    File['/etc/tuned/custom/tuned.conf']
-    ->
-    Exec['enable-tuned-profile']
+      File['/etc/tuned/custom/tuned.conf']
+      ->
+      Exec['enable-tuned-profile']
+    }
   }
 }

--- a/spec/classes/disable_transparent_hugepage_spec.rb
+++ b/spec/classes/disable_transparent_hugepage_spec.rb
@@ -4,6 +4,7 @@ describe 'disable_transparent_hugepage' do
   let(:facts) {{
     :osfamily                  => 'RedHat',
     :operatingsystemmajrelease => '7',
+    :tuned_base_profile        => 'virtual-guest',
   }}
   it {
     is_expected.to compile.with_all_deps

--- a/templates/tuned.conf.erb
+++ b/templates/tuned.conf.erb
@@ -1,5 +1,5 @@
 [main]
-include=virtual-guest
+include=<%= scope.lookupvar('::tuned_base_profile') %>
 
 [vm]
 transparent_hugepages=never


### PR DESCRIPTION
This fixes #1 by adding a pair of new custom puppet facts and incorporating them into the custom profile.
