### PR TITLE
Refactors custom fact

### DIFF
--- a/lib/facter/tuned_active.rb
+++ b/lib/facter/tuned_active.rb
@@ -1,34 +1,29 @@
 require 'facter'
 
 def get_active_profile
-  active_profile = ''
-  begin
-    if File.file?('/etc/tuned/active_profile') then
-      active_profile = File.read('/etc/tuned/active_profile').chomp
+  if File.exists?('/etc/tuned/active_profile') then
+    active_profile = File.read('/etc/tuned/active_profile').chomp
+  else
+    active_output = Facter::Util::Resolution.exec('tuned-adm active')
+    if active_output
+      active_profile = active_output.chomp.sub('Current active profile: ','')
     else
-      active_profile = `tuned-adm active`.chomp.sub('Current active profile: ','')
-      if $?.exitstatus != 0 then
-        active_profile = 'virtual-guest'
-      end
+      'virtual-guest'
     end
-  rescue
-    active_profile = 'virtual-guest'
   end
-
-  active_profile
 end
 
 Facter.add(:tuned_active_profile) do
   confine :kernel => "Linux"
   setcode do
-    get_active_profile()
+    get_active_profile
   end
 end
 
 Facter.add(:tuned_base_profile) do
   confine :kernel => "Linux"
   setcode do
-    active_profile = get_active_profile()
+    active_profile = get_active_profile
     base_profile = ""
     if active_profile == "custom" then
       begin

--- a/spec/unit/facter/tuned_active_spec.rb
+++ b/spec/unit/facter/tuned_active_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before {
+    Facter.clear
+  }
+
+  describe 'tuned_active_profile' do
+    context 'returns file content of /etc/tuned/active_profile when present' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        File.stubs(:exists?)
+        File.stubs(:read)
+        File.expects(:exists?).with('/etc/tuned/active_profile').returns(true)
+        Facter::Util::Resolution.stubs(:exec)
+      end
+      it do
+        active_profile_output = <<-EOS
+custom
+        EOS
+        File.expects(:read).with('/etc/tuned/active_profile').returns(active_profile_output)
+        expect(Facter.value(:tuned_active_profile)).to eq('custom')
+      end
+    end
+
+    context 'returns response of tuned-adm active when avaliable' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        File.stubs(:exists?)
+        File.stubs(:read)
+        File.expects(:exists?).with('/etc/tuned/active_profile').returns(false)
+        Facter::Util::Resolution.stubs(:exec)
+      end
+      it do
+        active_profile_output = <<-EOS
+Current active profile: custom
+        EOS
+        Facter::Util::Resolution.expects(:exec).with('tuned-adm active').returns(active_profile_output)
+        expect(Facter.value(:tuned_active_profile)).to eq('custom')
+      end
+    end
+
+    context 'returns virtual-guest if all else fails' do
+      before do
+        Facter.fact(:kernel).stubs(:value).returns("Linux")
+        File.stubs(:exists?)
+        File.stubs(:read)
+        File.expects(:exists?).with('/etc/tuned/active_profile').returns(false)
+        File.expects(:exists?).with('/proc/cpuinfo').returns(false)
+        Facter::Util::Resolution.stubs(:exec)
+      end
+      it do
+        active_profile_output = <<-EOS
+Current active profile: custom
+        EOS
+        Facter::Util::Resolution.expects(:exec).with('tuned-adm active').returns(nil)
+        expect(Facter.value(:tuned_active_profile)).to eq('virtual-guest')
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
- Change to snake case name (Ruby consistency)
- Use Facter's exec method, backticks are inconsistent and sometimes run on systems regardless of confine
- Adds spec for active profile
